### PR TITLE
Allow specifying encoding when getting strings

### DIFF
--- a/aioredis_models/redis_string.py
+++ b/aioredis_models/redis_string.py
@@ -22,7 +22,7 @@ class RedisString(RedisKey):
 
         return await self._redis.strlen(self._key)
 
-    async def get(self) -> str:
+    async def get(self, encoding='utf-8') -> str:
         """
         Gets the stored value of the string.
 
@@ -30,7 +30,7 @@ class RedisString(RedisKey):
             str: The value of the string.
         """
 
-        return await self._redis.get(self._key)
+        return await self._redis.get(self._key, encoding=encoding)
 
     async def set(
         self,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ HERE = pathlib.Path(__file__).parent
 README = (HERE / "README.md").read_text()
 setup(
     name="aioredis-models",
-    version="1.0.1",
+    version="1.1.0",
     description="Model Redis data structures",
     long_description=README,
     long_description_content_type="text/markdown",
@@ -15,7 +15,6 @@ setup(
     license="MIT",
     classifiers=[
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/tests/redis_string_tests.py
+++ b/tests/redis_string_tests.py
@@ -23,11 +23,22 @@ class RedisStringTests(unittest.IsolatedAsyncioTestCase):
         redis = AsyncMock()
         key = MagicMock()
         redis_string = RedisString(redis, key)
+        encoding = MagicMock()
+
+        result = await redis_string.get(encoding=encoding)
+
+        self.assertEqual(result, redis.get.return_value)
+        redis.get.assert_awaited_once_with(key, encoding=encoding)
+
+    async def test_get_with_default_encoding_uses_utf8(self):
+        redis = AsyncMock()
+        key = MagicMock()
+        redis_string = RedisString(redis, key)
 
         result = await redis_string.get()
 
         self.assertEqual(result, redis.get.return_value)
-        redis.get.assert_awaited_once_with(key)
+        redis.get.assert_awaited_once_with(key, encoding='utf-8')
 
     async def test_set_with_if_exist_equals_true_sets_correctly(self):
         redis = AsyncMock()


### PR DESCRIPTION
* allow specifying encoding on `RedisString.get`