### PR TITLE
Refactor RedisList.find_index to use enumerate

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.0
+current_version = 2.0.0
 commit = False
 tag = False
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 Dockerfile
 docker-compose.yaml
 test-reports/
+e2e-reports/

--- a/.github/workflows/python-quality-check.yaml
+++ b/.github/workflows/python-quality-check.yaml
@@ -15,20 +15,23 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      - name: Install requirements
-        run: pip install -r requirements.txt
       - name: Run unit tests
-        run: tox -e unit-py39
+        run: docker-compose up --build unit-test
       - name: Upload coverage to Codecov
         if: success() && github.ref == 'refs/heads/main'
         uses: codecov/codecov-action@v1
         with:
           directory: ./test-reports/
-          flags: unittests
+          flags: unit-tests
+          fail_ci_if_error: true
+      - name: Run e2e tests
+        run: docker-compose up --build e2e-test
+      - name: Upload coverage to Codecov
+        if: success() && github.ref == 'refs/heads/main'
+        uses: codecov/codecov-action@v1
+        with:
+          directory: ./e2e-reports/
+          flags: e2e-tests
           fail_ci_if_error: true
       - name: Lint Python code
-        run: pylint aioredis_models
+        run: docker-compose up --build lint

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 test-reports/
+e2e-reports/
 
 # Translations
 *.mo

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A wrapper over [aioredis](https://github.com/aio-libs/aioredis) that models
 
 ![GitHub Workflow Status (event)](https://img.shields.io/github/workflow/status/qcrisw/aioredis-models/quality-check?event=push&label=quality-checks)
 [![Documentation Status](https://readthedocs.org/projects/aioredis-models/badge/?version=latest)](https://aioredis-models.readthedocs.io/en/latest/?badge=latest)
-[![codecov](https://codecov.io/gh/qcrisw/aioredis-models/branch/main/graph/badge.svg?token=5K5M77QXO5)](https://codecov.io/gh/qcrisw/aioredis-models)
+[![codecov](https://codecov.io/gh/qcrisw/aioredis-models/branch/main/graph/badge.svg?token=5K5M77QXO5&flag=unit-tests)](https://codecov.io/gh/qcrisw/aioredis-models)
 ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/qcrisw/aioredis-models/publish-package?label=package-publish)
 
 ## Supported data structures

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,5 +20,7 @@ services:
     command: tox -e e2e-py39
     environment:
       REDIS_URL: redis://redis:6379/0
+    volumes:
+    - ./e2e-reports:/home/test-reports
     depends_on:
     - redis

--- a/e2e/redis_list_tests.py
+++ b/e2e/redis_list_tests.py
@@ -18,3 +18,35 @@ class RedisListTests(RedisTests):
         result = [item async for item in self._redis_list.enumerate(batch_size=2)]
 
         self.assertEqual(result, values)
+
+    async def test_find_index_with_start_stop_batch_size_finds_result(self):
+        values = ['this', 'is', 'a', 'very', 'valuable', 'test']
+        await self._redis_list.push(*values, reverse=True)
+
+        result = await self._redis_list.find_index('very', batch_size=2)
+
+        self.assertEqual(result, values.index('very'))
+
+    async def test_find_index_with_start_stop_batch_size_does_not_find_result_not_in_range(self):
+        values = ['this', 'is', 'a', 'very', 'valuable', 'test']
+        await self._redis_list.push(*values, reverse=True)
+
+        result = await self._redis_list.find_index('valuable', start=1, stop=3, batch_size=2)
+
+        self.assertIsNone(result)
+
+    async def test_find_index_with_no_stop_finds_result(self):
+        values = ['this', 'is', 'a', 'very', 'valuable', 'test']
+        await self._redis_list.push(*values, reverse=True)
+
+        result = await self._redis_list.find_index('valuable', start=1, batch_size=2)
+
+        self.assertEqual(result, values.index('valuable'))
+
+    async def test_find_index_with_no_stop_does_not_find_missing_result(self):
+        values = ['this', 'is', 'a', 'very', 'valuable', 'test']
+        await self._redis_list.push(*values, reverse=True)
+
+        result = await self._redis_list.find_index('code', start=1, batch_size=2)
+
+        self.assertIsNone(result)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ HERE = pathlib.Path(__file__).parent
 README = (HERE / "README.md").read_text()
 setup(
     name="aioredis-models",
-    version="1.2.0",
+    version="2.0.0",
     description="Model Redis data structures",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
* add CI check for e2e tests
* refactor `RedisList.find_index` to use `enumerate` instead of `get_range`
* bump major version due to breaking change in `RedisList`