### PR TITLE
Make RedisDoubleHash more atomic and transactional

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.0
+current_version = 2.2.0
 commit = False
 tag = False
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,13 @@ To run directly on the host:
 
 ``` bash
 pip3 install -r requirements.txt
-tox
+tox -e unit-py39
+```
+
+End-to-end tests can also be run with [docker-compose]:
+
+``` bash
+docker-compose up --build e2e-test
 ```
 
 ### Linting

--- a/aioredis_models/redis_transaction.py
+++ b/aioredis_models/redis_transaction.py
@@ -3,7 +3,7 @@ This module contains the following classes:
 - RedisTransaction: Represents a Redis transaction.
 """
 
-from typing import List
+from typing import Any, Callable, List, Tuple
 from asyncio import Future, gather
 
 
@@ -13,6 +13,7 @@ class RedisTransaction:
     """
 
     _tasks: List[Future]
+    _result_callback: Callable[[Tuple[Any, ...]], Any]
 
     def __init__(self, redis_client):
         """
@@ -23,6 +24,7 @@ class RedisTransaction:
         """
         self._redis_client = redis_client
         self._tasks = []
+        self._result_callback = None
 
     async def __aenter__(self):
         return self
@@ -30,7 +32,9 @@ class RedisTransaction:
     async def __aexit__(self, exc_type, exc, traceback):
         if not exc:
             await self._redis_client.execute_transaction()
-            await gather(*self._tasks)
+            result = await gather(*self._tasks)
+            if self._result_callback:
+                self._result_callback(*result)
         else:
             self._redis_client.discard_transaction()
             for task in self._tasks:
@@ -45,3 +49,14 @@ class RedisTransaction:
             operations that support transactions.
         """
         self._tasks.extend(tasks)
+
+    def set_result_callback(self, callback: Callable[[Tuple[Any, ...]], Any]):
+        """
+        Sets a callback function to be called with the result of the transaction when it completes.
+
+        Args:
+            callback (Callable[[Tuple[Any, ...]], Any]): The function to call. Accepts positional
+                arguments containing results of operations in the same order as they were added
+                to the transaction using calls to `add_operation`.
+        """
+        self._result_callback = callback

--- a/e2e/redis_double_hash_tests.py
+++ b/e2e/redis_double_hash_tests.py
@@ -1,0 +1,118 @@
+from aioredis_models import RedisDoubleHash
+from .redis_tests import RedisTests
+
+
+class RedisDoubleHashTests(RedisTests):
+    _key = 'test-key'
+    _inverse_key = 'key-test'
+    _redis_double_hash: RedisDoubleHash = None
+
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+
+        self._redis_double_hash = RedisDoubleHash(self._redis, self._key, self._inverse_key)
+        await self._redis_double_hash.delete()
+
+    async def test_fields_gets_fields(self):
+        await self._redis_double_hash.set('foo', 'bar')
+        await self._redis_double_hash.set('foo', 'bat')
+        await self._redis_double_hash.set('biz', 'boo')
+
+        result = await self._redis_double_hash.fields()
+
+        self.assertEqual(result, {'foo', 'biz'})
+
+    async def test_fields_inverted_gets_inverted_fields(self):
+        await self._redis_double_hash.set('foo', 'bar')
+        await self._redis_double_hash.set('foo', 'bat')
+        await self._redis_double_hash.set('biz', 'boo')
+
+        result = await self._redis_double_hash.fields_inverted()
+
+        self.assertEqual(result, {'bar', 'bat', 'boo'})
+
+    async def test_set_sets_mapping(self):
+        await self._redis_double_hash.set('foo', 'bar')
+        await self._redis_double_hash.set('foo', 'bat')
+
+        foo = await self._redis_double_hash.get('foo')
+        bar = await self._redis_double_hash.get_inverted('bar')
+        bat = await self._redis_double_hash.get_inverted('bat')
+
+        self.assertEqual(foo, ['bar', 'bat'])
+        self.assertEqual(bar, ['foo'])
+        self.assertEqual(bat, ['foo'])
+
+    async def test_set_inverted_sets_mapping(self):
+        await self._redis_double_hash.set_inverted('foo', 'bar')
+        await self._redis_double_hash.set_inverted('foo', 'bat')
+
+        bar = await self._redis_double_hash.get('bar')
+        bat = await self._redis_double_hash.get('bat')
+        foo = await self._redis_double_hash.get_inverted('foo')
+
+        self.assertEqual(foo, ['bar', 'bat'])
+        self.assertEqual(bar, ['foo'])
+        self.assertEqual(bat, ['foo'])
+
+    async def test_unset_unsets_mapping(self):
+        await self._redis_double_hash.set('foo', 'bar')
+        await self._redis_double_hash.set('foo', 'bat')
+
+        await self._redis_double_hash.unset('foo', 'bat')
+
+        foo = await self._redis_double_hash.get('foo')
+        bar = await self._redis_double_hash.get_inverted('bar')
+        bat = await self._redis_double_hash.get_inverted('bat')
+
+        self.assertEqual(foo, ['bar'])
+        self.assertEqual(bar, ['foo'])
+        self.assertEqual(bat, [])
+
+    async def test_remove_removes_mapping(self):
+        await self._redis_double_hash.set('foo', 'bar')
+        await self._redis_double_hash.set('foo', 'bat')
+        await self._redis_double_hash.set('bar', 'foo')
+
+        await self._redis_double_hash.remove('foo')
+
+        foo = await self._redis_double_hash.get('foo')
+        bar_fwd = await self._redis_double_hash.get('bar')
+        bar_bwd = await self._redis_double_hash.get_inverted('bar')
+        bat = await self._redis_double_hash.get_inverted('bat')
+
+        self.assertEqual(foo, [])
+        self.assertEqual(bar_fwd, ['foo'])
+        self.assertEqual(bar_bwd, [])
+        self.assertEqual(bat, [])
+
+    async def test_remove_inverted_removes_mapping(self):
+        await self._redis_double_hash.set('foo', 'bar')
+        await self._redis_double_hash.set('foo', 'bat')
+        await self._redis_double_hash.set('biz', 'bat')
+
+        await self._redis_double_hash.remove_inverted('bat')
+
+        foo = await self._redis_double_hash.get('foo')
+        biz = await self._redis_double_hash.get('biz')
+        bar = await self._redis_double_hash.get_inverted('bar')
+        bat = await self._redis_double_hash.get_inverted('bat')
+
+        self.assertEqual(foo, ['bar'])
+        self.assertEqual(biz, [])
+        self.assertEqual(bar, ['foo'])
+        self.assertEqual(bat, [])
+
+    async def test_delete_deletes_all(self):
+        await self._redis_double_hash.set('foo', 'bar')
+        await self._redis_double_hash.set('foo', 'bat')
+
+        await self._redis_double_hash.delete()
+
+        foo = await self._redis_double_hash.get('foo')
+        bar = await self._redis_double_hash.get_inverted('bar')
+        bat = await self._redis_double_hash.get_inverted('bat')
+
+        self.assertFalse(foo)
+        self.assertFalse(bar)
+        self.assertFalse(bat)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ HERE = pathlib.Path(__file__).parent
 README = (HERE / "README.md").read_text()
 setup(
     name="aioredis-models",
-    version="2.1.0",
+    version="2.2.0",
     description="Model Redis data structures",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/redis_double_hash_tests.py
+++ b/tests/redis_double_hash_tests.py
@@ -1,7 +1,18 @@
+from functools import partial
 import unittest
 from unittest.mock import MagicMock, AsyncMock, call, patch
 from aioredis_models.redis_double_hash import RedisDoubleHash
 
+
+def assert_transaction(transaction_ctx, return_value, *_, **__):
+    transaction_ctx.__aenter__.assert_awaited_once()
+    transaction_ctx.__aexit__.assert_not_awaited()
+    return return_value
+
+def assert_pre_transaction(transaction_ctx, return_value, *_, **__):
+    transaction_ctx.__aenter__.assert_not_awaited()
+    transaction_ctx.__aexit__.assert_not_awaited()
+    return return_value
 
 class RedisDoubleHashTests(unittest.IsolatedAsyncioTestCase):
     def test_init_succeeds(self):
@@ -36,33 +47,37 @@ class RedisDoubleHashTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, set(fields))
 
     @patch('aioredis_models.redis_double_hash.RedisSet')
-    async def test_get_works_correctly(self, redis_set_init):
-        redis_set_init.return_value.get_all = AsyncMock()
-        redis = AsyncMock()
+    @patch('aioredis_models.redis_model.isinstance')
+    def test_get_works_correctly(self, isinstance_mock, redis_set_init):
+        redis = MagicMock()
+        isinstance_mock.return_value = True
         key = 'some-key'
         inverse_key = MagicMock()
         redis_double_hash = RedisDoubleHash(redis, key, inverse_key)
         field = 'some-field'
 
-        result = await redis_double_hash.get(field)
+        result = redis_double_hash.get(field)
 
         redis_set_init.assert_called_once_with(redis, f'{key}:{field}')
-        redis_set_init.return_value.get_all.assert_awaited_once_with()
+        redis_set_init.return_value.get_all.assert_called_once_with()
         self.assertEqual(result, redis_set_init.return_value.get_all.return_value)
 
     @patch('aioredis_models.redis_double_hash.RedisSet')
-    async def test_get_inverted_works_correctly(self, redis_set_init):
-        redis_set_init.return_value.get_all = AsyncMock()
-        redis = AsyncMock()
+    @patch('aioredis_models.redis_model.RedisClient')
+    @patch('aioredis_models.redis_model.isinstance')
+    def test_get_inverted_works_correctly(self, isinstance_mock, redis_client_init, redis_set_init):
+        redis = MagicMock()
+        isinstance_mock.return_value = False
         key = MagicMock()
         inverse_key = 'some-key'
         redis_double_hash = RedisDoubleHash(redis, key, inverse_key)
         field = 'some-field'
 
-        result = await redis_double_hash.get_inverted(field)
+        result = redis_double_hash.get_inverted(field)
 
-        redis_set_init.assert_called_once_with(redis, f'{inverse_key}:{field}')
-        redis_set_init.return_value.get_all.assert_awaited_once_with()
+        redis_client_init.assert_called_once_with(redis)
+        redis_set_init.assert_called_once_with(redis_client_init.return_value, f'{inverse_key}:{field}')
+        redis_set_init.return_value.get_all.assert_called_once_with()
         self.assertEqual(result, redis_set_init.return_value.get_all.return_value)
 
     @staticmethod
@@ -73,12 +88,19 @@ class RedisDoubleHashTests(unittest.IsolatedAsyncioTestCase):
 
     @staticmethod
     @patch('aioredis_models.redis_double_hash.RedisSet')
-    async def test_set_with_value_sets_value(redis_set_init):
+    @patch('aioredis_models.redis_model.isinstance')
+    async def test_set_with_value_sets_value(isinstance_mock, redis_set_init):
+        redis = MagicMock()
+        isinstance_mock.return_value = True
+        transaction_ctx = AsyncMock()
+        transaction = MagicMock()
+        transaction.add_operation.side_effect = partial(assert_transaction, transaction_ctx, True)
+        transaction_ctx.__aenter__.return_value = transaction
+        redis.begin_transaction.return_value = transaction_ctx
         redis_sets = [MagicMock(), MagicMock()]
         for redis_set in redis_sets:
-            redis_set.add = AsyncMock()
+            redis_set.add.side_effect = partial(assert_transaction, transaction_ctx, redis_set.add.return_value)
         redis_set_init.side_effect = redis_sets
-        redis = AsyncMock()
         key = 'some-key'
         inverse_key = 'some-inverse-key'
         redis_double_hash = RedisDoubleHash(redis, key, inverse_key)
@@ -91,8 +113,14 @@ class RedisDoubleHashTests(unittest.IsolatedAsyncioTestCase):
             call(redis, f'{key}:{field}'),
             call(redis, f'{inverse_key}:{value}')
         ])
-        redis_sets[0].add.assert_awaited_once_with(value)
-        redis_sets[1].add.assert_awaited_once_with(field)
+        redis_sets[0].add.assert_called_once_with(value)
+        redis_sets[1].add.assert_called_once_with(field)
+        transaction_ctx.__aenter__.assert_awaited_once()
+        transaction_ctx.__aexit__.assert_awaited_once()
+        transaction.add_operation.assert_called_once_with(
+            redis_sets[0].add.return_value,
+            redis_sets[1].add.return_value
+        )
 
     async def test_set_inverted_with_none_value_does_nothing(self):
         redis_double_hash = RedisDoubleHash(None, MagicMock(), MagicMock())
@@ -101,12 +129,19 @@ class RedisDoubleHashTests(unittest.IsolatedAsyncioTestCase):
 
     @staticmethod
     @patch('aioredis_models.redis_double_hash.RedisSet')
-    async def test_set_inverted_with_value_sets_inverted_value(redis_set_init):
+    @patch('aioredis_models.redis_model.isinstance')
+    async def test_set_inverted_with_value_sets_inverted_value(isinstance_mock, redis_set_init):
+        redis = MagicMock()
+        isinstance_mock.return_value = True
+        transaction_ctx = AsyncMock()
+        transaction = MagicMock()
+        transaction.add_operation.side_effect = partial(assert_transaction, transaction_ctx, True)
+        transaction_ctx.__aenter__.return_value = transaction
+        redis.begin_transaction.return_value = transaction_ctx
         redis_sets = [MagicMock(), MagicMock()]
         for redis_set in redis_sets:
-            redis_set.add = AsyncMock()
+            redis_set.add.side_effect = partial(assert_transaction, transaction_ctx, redis_set.add.return_value)
         redis_set_init.side_effect = redis_sets
-        redis = AsyncMock()
         key = 'some-key'
         inverse_key = 'some-inverse-key'
         redis_double_hash = RedisDoubleHash(redis, key, inverse_key)
@@ -119,8 +154,14 @@ class RedisDoubleHashTests(unittest.IsolatedAsyncioTestCase):
             call(redis, f'{key}:{value}'),
             call(redis, f'{inverse_key}:{field}')
         ])
-        redis_sets[0].add.assert_awaited_once_with(field)
-        redis_sets[1].add.assert_awaited_once_with(value)
+        redis_sets[0].add.assert_called_once_with(field)
+        redis_sets[1].add.assert_called_once_with(value)
+        transaction_ctx.__aenter__.assert_awaited_once()
+        transaction_ctx.__aexit__.assert_awaited_once()
+        transaction.add_operation.assert_called_once_with(
+            redis_sets[0].add.return_value,
+            redis_sets[1].add.return_value
+        )
 
     @staticmethod
     async def test_unset_with_none_value_does_nothing():
@@ -130,12 +171,19 @@ class RedisDoubleHashTests(unittest.IsolatedAsyncioTestCase):
 
     @staticmethod
     @patch('aioredis_models.redis_double_hash.RedisSet')
-    async def test_unset_with_value_unsets_value(redis_set_init):
+    @patch('aioredis_models.redis_model.isinstance')
+    async def test_unset_with_value_unsets_value(isinstance_mock, redis_set_init):
+        redis = MagicMock()
+        isinstance_mock.return_value = True
+        transaction_ctx = AsyncMock()
+        transaction = MagicMock()
+        transaction.add_operation.side_effect = partial(assert_transaction, transaction_ctx, True)
+        transaction_ctx.__aenter__.return_value = transaction
+        redis.begin_transaction.return_value = transaction_ctx
         redis_sets = [MagicMock(), MagicMock()]
         for redis_set in redis_sets:
-            redis_set.remove = AsyncMock()
+            redis_set.remove.side_effect = partial(assert_transaction, transaction_ctx, redis_set.remove.return_value)
         redis_set_init.side_effect = redis_sets
-        redis = AsyncMock()
         key = 'some-key'
         inverse_key = 'some-inverse-key'
         redis_double_hash = RedisDoubleHash(redis, key, inverse_key)
@@ -148,22 +196,39 @@ class RedisDoubleHashTests(unittest.IsolatedAsyncioTestCase):
             call(redis, f'{key}:{field}'),
             call(redis, f'{inverse_key}:{value}')
         ])
-        redis_sets[0].remove.assert_awaited_once_with(value)
-        redis_sets[1].remove.assert_awaited_once_with(field)
+        redis_sets[0].remove.assert_called_once_with(value)
+        redis_sets[1].remove.assert_called_once_with(field)
+        transaction_ctx.__aenter__.assert_awaited_once()
+        transaction_ctx.__aexit__.assert_awaited_once()
+        transaction.add_operation.assert_called_once_with(
+            redis_sets[0].remove.return_value,
+            redis_sets[1].remove.return_value
+        )
 
     @staticmethod
     @patch('aioredis_models.redis_double_hash.RedisSet')
-    async def test_remove_removes_field(redis_set_init):
+    @patch('aioredis_models.redis_model.isinstance')
+    async def test_remove_removes_field(isinstance_mock, redis_set_init):
+        redis = MagicMock()
+        isinstance_mock.return_value = True
+        transaction_ctx = AsyncMock()
+        transaction = MagicMock()
+        transaction.add_operation.side_effect = partial(assert_transaction, transaction_ctx, True)
+        transaction_ctx.__aenter__.return_value = transaction
+        redis.begin_transaction.return_value = transaction_ctx
         mock_field_set = MagicMock()
         values = ['value1', 'value2']
-        mock_field_set.get_all = AsyncMock(return_value=values)
-        mock_field_set.delete = AsyncMock()
+        mock_field_set.get_all = AsyncMock()
+        mock_field_set.get_all.side_effect = partial(assert_pre_transaction, transaction_ctx, values)
+        mock_field_set.delete = MagicMock()
+        mock_field_set.delete.side_effect = partial(assert_transaction, transaction_ctx, mock_field_set.delete.return_value)
         mock_value_sets = [MagicMock(), MagicMock()]
         for redis_set in mock_value_sets:
-            redis_set.remove = AsyncMock()
+            redis_set.remove = MagicMock()
+            redis_set.remove.side_effect = partial(assert_transaction, transaction_ctx, redis_set.remove.return_value)
         redis_sets = [mock_field_set, *mock_value_sets]
         redis_set_init.side_effect = redis_sets
-        redis = AsyncMock()
+
         key = 'some-key'
         inverse_key = 'some-inverse-key'
         redis_double_hash = RedisDoubleHash(redis, key, inverse_key)
@@ -175,23 +240,41 @@ class RedisDoubleHashTests(unittest.IsolatedAsyncioTestCase):
             call(redis, f'{inverse_key}:{value}') for value in values
         ])
         redis_sets[0].get_all.assert_awaited_once_with()
-        redis_sets[0].delete.assert_awaited_once_with()
-        for index in range(len(values)):
-            redis_sets[index+1].remove.assert_awaited_once_with(field)
+        redis_sets[0].delete.assert_called_once_with()
+        transaction_ctx.__aenter__.assert_awaited_once()
+        transaction_ctx.__aexit__.assert_awaited_once()
+        for redis_set in redis_sets[1:]:
+            redis_set.remove.assert_called_once_with(field)
+        transaction.add_operation.assert_has_calls([
+            call(mock_field_set.delete.return_value)
+        ] + [
+            call(redis_set.remove.return_value) for redis_set in redis_sets[1:]
+        ])
 
     @staticmethod
     @patch('aioredis_models.redis_double_hash.RedisSet')
-    async def test_remove_inverted_removes_value(redis_set_init):
-        mock_value_set = MagicMock()
+    @patch('aioredis_models.redis_model.isinstance')
+    async def test_remove_inverted_removes_value(isinstance_mock, redis_set_init):
+        redis = MagicMock()
+        isinstance_mock.return_value = True
+        transaction_ctx = AsyncMock()
+        transaction = MagicMock()
+        transaction.add_operation.side_effect = partial(assert_transaction, transaction_ctx, True)
+        transaction_ctx.__aenter__.return_value = transaction
+        redis.begin_transaction.return_value = transaction_ctx
+        mock_field_set = MagicMock()
         fields = ['field1', 'field2']
-        mock_value_set.get_all = AsyncMock(return_value=fields)
-        mock_value_set.delete = AsyncMock()
-        mock_field_sets = [MagicMock(), MagicMock()]
-        for redis_set in mock_field_sets:
-            redis_set.remove = AsyncMock()
-        redis_sets = [mock_value_set, *mock_field_sets]
+        mock_field_set.get_all = AsyncMock()
+        mock_field_set.get_all.side_effect = partial(assert_pre_transaction, transaction_ctx, fields)
+        mock_field_set.delete = MagicMock()
+        mock_field_set.delete.side_effect = partial(assert_transaction, transaction_ctx, mock_field_set.delete.return_value)
+        mock_value_sets = [MagicMock(), MagicMock()]
+        for redis_set in mock_value_sets:
+            redis_set.remove = MagicMock()
+            redis_set.remove.side_effect = partial(assert_transaction, transaction_ctx, redis_set.remove.return_value)
+        redis_sets = [mock_field_set, *mock_value_sets]
         redis_set_init.side_effect = redis_sets
-        redis = AsyncMock()
+
         key = 'some-key'
         inverse_key = 'some-inverse-key'
         redis_double_hash = RedisDoubleHash(redis, key, inverse_key)
@@ -203,20 +286,42 @@ class RedisDoubleHashTests(unittest.IsolatedAsyncioTestCase):
             call(redis, f'{key}:{field}') for field in fields
         ])
         redis_sets[0].get_all.assert_awaited_once_with()
-        redis_sets[0].delete.assert_awaited_once_with()
-        for index in range(len(fields)):
-            redis_sets[index+1].remove.assert_awaited_once_with(value)
+        redis_sets[0].delete.assert_called_once_with()
+        transaction_ctx.__aenter__.assert_awaited_once()
+        transaction_ctx.__aexit__.assert_awaited_once()
+        for redis_set in redis_sets[1:]:
+            redis_set.remove.assert_called_once_with(value)
+        transaction.add_operation.assert_has_calls([
+            call(mock_field_set.delete.return_value)
+        ] + [
+            call(redis_set.remove.return_value) for redis_set in redis_sets[1:]
+        ])
 
     @staticmethod
     @patch('aioredis_models.redis_double_hash.RedisKey')
-    async def test_delete_deletes_both_sides(redis_key_init):
+    @patch('aioredis_models.redis_model.isinstance')
+    async def test_delete_deletes_both_sides(isinstance_mock, redis_key_init):
         fields = [MagicMock() for _ in range(12)]
         values = [MagicMock() for _ in range(19)]
         redis = MagicMock()
-        redis.keys = AsyncMock(side_effect=[fields, values])
+        connections = [MagicMock(), MagicMock()] + ([MagicMock()] * len(fields + values))
+        transaction_ctxs = [AsyncMock(), AsyncMock()]
+        transactions = [MagicMock(), MagicMock()]
+        for index in range(len(transactions)):
+            transaction_ctxs[index].__aenter__.return_value = transactions[index]
+            transactions[index].add_operation.side_effect = partial(assert_transaction, transaction_ctxs[index], MagicMock())
+        transactions[0].set_result_callback.side_effect = \
+            lambda callback: assert_transaction(transaction_ctxs[0], True) and callback(fields, values)
+        transactions[1].set_result_callback = None
+        for connection in connections[:2]:
+            connection.keys.side_effect = partial(assert_transaction, transaction_ctxs[0], connection.keys.return_value)
+        redis.get_connection.side_effect = connections
+        redis.begin_transaction.side_effect = transaction_ctxs
+        isinstance_mock.return_value = True
         redis_keys = [MagicMock() for _ in range(len(fields + values))]
         for redis_key in redis_keys:
-            redis_key.delete = AsyncMock()
+            redis_key.delete = MagicMock()
+            redis_key.delete.side_effect = partial(assert_transaction, transaction_ctxs[1], redis_key.delete.return_value)
         redis_key_init.side_effect = redis_keys
         key = 'some-key'
         inverse_key = 'some-inverse-key'
@@ -224,12 +329,16 @@ class RedisDoubleHashTests(unittest.IsolatedAsyncioTestCase):
 
         await redis_double_hash.delete()
 
-        redis.keys.assert_has_awaits([
-            call(key + ':*', encoding='utf-8'),
-            call(inverse_key + ':*', encoding='utf-8')
-        ])
+        connections[0].keys.assert_called_once_with(key + ':*', encoding='utf-8')
+        connections[1].keys.assert_called_once_with(inverse_key + ':*', encoding='utf-8')
         redis_key_init.assert_has_calls([
-            call(redis, key) for key in fields + values
-        ])
+            call(connections[2], key) for key in fields + values
+        ], any_order=True)
         for redis_key in redis_keys:
-            redis_key.delete.assert_awaited_once_with()
+            redis_key.delete.assert_called_once_with()
+        transactions[0].add_operation.assert_called_once_with(*(
+            connection.keys.return_value for connection in connections[:2]
+        ))
+        transactions[1].add_operation.assert_called_once_with(*(
+            redis_keys[index].delete.return_value for index in range(len(redis_keys))
+        ))

--- a/tests/redis_transaction_tests.py
+++ b/tests/redis_transaction_tests.py
@@ -17,7 +17,7 @@ class RedisTransactionTests(unittest.IsolatedAsyncioTestCase):
 
     @staticmethod
     @patch('aioredis_models.redis_transaction.gather', new_callable=AsyncMock)
-    async def test_aexit_with_no_expection_executes_transaction(gather_mock):
+    async def test_aexit_with_no_exception_executes_transaction(gather_mock):
         client = AsyncMock()
         rtx = RedisTransaction(client)
         tasks = [MagicMock() for _ in range(4)]
@@ -30,7 +30,7 @@ class RedisTransactionTests(unittest.IsolatedAsyncioTestCase):
 
     @staticmethod
     @patch('aioredis_models.redis_transaction.gather', new_callable=AsyncMock)
-    async def test_aexit_with_expection_discards_transaction(gather_mock):
+    async def test_aexit_with_exception_discards_transaction(gather_mock):
         client = MagicMock()
         client.execute_transaction = None
         rtx = RedisTransaction(client)
@@ -43,3 +43,20 @@ class RedisTransactionTests(unittest.IsolatedAsyncioTestCase):
         for task in tasks:
             task.cancel.assert_called_once_with()
         gather_mock.assert_not_awaited()
+
+    @staticmethod
+    @patch('aioredis_models.redis_transaction.gather', new_callable=AsyncMock)
+    async def test_set_result_callback_registers_callback(gather_mock):
+        client = AsyncMock()
+        rtx = RedisTransaction(client)
+        tasks = [MagicMock() for _ in range(43)]
+        result_callback = MagicMock()
+        gather_mock.return_value = [task.return_value for task in tasks]
+
+        rtx.add_operation(*tasks)
+        rtx.set_result_callback(result_callback)
+        await rtx.__aexit__(None, None, None)
+
+        result_callback.assert_called_once_with(
+            *gather_mock.return_value
+        )


### PR DESCRIPTION
* update deprecated syntax in `setup.cfg`
* add e2e instructions to `README.md`
* expose transaction results from `RedisTransaction`
* make `RedisDoubleHash` more atomic and transactional
* bump minor version